### PR TITLE
Fix vocalization and chrome 73; refs #18072

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -149,3 +149,36 @@ chrome.contextMenus.onClicked.addListener(function(info, tab) {
   ChromeBabelFrog.activate(tab);
 });
 
+/**
+ * Google translate service request.
+ */
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+  // flag to designate type of message
+  if (request.msgId != 'googleTranslate') {
+    return;
+  }
+
+  var ajax = new XMLHttpRequest();
+  var serviceUrl = request.url + "?" + request.params;
+
+  ajax.open("GET", serviceUrl, true);
+  ajax.send();
+
+  ajax.onreadystatechange = function() {
+    var result = {};
+    if (ajax.readyState === 4) {
+      if (ajax.status === 200) {
+        result.status = true;
+        result.data = ajax.responseText;
+      } else {
+        result.status = false;
+        result.message = ajax.statusText;
+      }
+      sendResponse(result);
+    }
+  }
+
+  // Will respond asynchronously.
+  return true;
+});
+

--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -5,7 +5,15 @@ ChromeBabelFrog.play = function(url) {
     ChromeBabelFrog.currentlyPlaying.pause();
   }
   ChromeBabelFrog.currentlyPlaying = new Audio(url);
-  ChromeBabelFrog.currentlyPlaying.play();
+  var promise = ChromeBabelFrog.currentlyPlaying.play();
+
+  if (promise !== undefined) {
+    promise.then(_ => {
+      console.log('Autoplay started');
+    }).catch(error => {
+      console.error('Autoplay was prevented.');
+    });
+  }
 }
 
 ChromeBabelFrog.capitalize = function(str) {
@@ -93,7 +101,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   var text = encodeURIComponent(request.text);
   var url = 'http://translate.google.com/translate_tts?ie=UTF-8&tl='
             + settings.get('srcLang')
-            + '&total=1&idx=0&textlen=77&client=t&prev=input&q='
+            + '&total=1&idx=0&textlen=77&client=babelfrog&prev=input&q='
             + text;
   console.log("vocalizing", url);
   ChromeBabelFrog.play(url);

--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -158,10 +158,32 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     return;
   }
 
-  var ajax = new XMLHttpRequest();
-  var serviceUrl = request.url + "?" + request.params;
+  httpGetRequest(request.url, request.params, sendResponse);
 
-  ajax.open("GET", serviceUrl, true);
+  // Will respond asynchronously.
+  return true;
+});
+
+/**
+ * Ajax call wrapper.
+ *
+ * @arg string url
+ *   Request URL without parameters.
+ * @arg object params
+ *   Get request data in value-key pairs.
+ * @arg function callback
+ *   The callback function with one object argument, the response.
+ */
+function httpGetRequest(url, params, callback) {
+  var ajax = new XMLHttpRequest();
+  var paramsAux = [];
+
+  // Transform object into an array.
+  for (var key in params) {
+    paramsAux.push(key + '=' + encodeURIComponent(params[key]));
+  }
+
+  ajax.open('GET', url + '?' + paramsAux.join('&'), true);
   ajax.send();
 
   ajax.onreadystatechange = function() {
@@ -174,11 +196,8 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
         result.status = false;
         result.message = ajax.statusText;
       }
-      sendResponse(result);
+      result.code = ajax.status;
+      callback(result);
     }
-  }
-
-  // Will respond asynchronously.
-  return true;
-});
-
+  };
+}

--- a/src/inject/babelfrog.js
+++ b/src/inject/babelfrog.js
@@ -412,12 +412,29 @@ BabelFrog.engines.googleTranslate = function(sourceText){
 
 // Potentially illegitimate use of non-public API; but many other extensions use it too.
 BabelFrog.engines.googleTranslateFree = function(sourceText){
-  jQuery.ajax({
-    url:'https://translate.google.com/translate_a/single',
-    type: 'GET',
-    dataType: 'json',
-    success: function(response){
+  var url = 'https://translate.google.com/translate_a/single',
+    urlParams = {
+      // appear as the official Google Translate chrome extension
+      client: 'gtx',
+      hl: 'en-US',
+      source: 'bubble',
+      tk: (Math.floor((new Date).getTime() / 36E5) ^ 123456) + "|" + (Math.floor((Math.sqrt(5) - 1) / 2 * ((Math.floor((new Date).getTime() / 36E5) ^ 123456) ^ 654321) % 1 * 1048576)),
+      dt: 'bd',
+      dt: 't',
+      dj: 1,
+      sl: BabelFrog.config.source,
+      tl: BabelFrog.config.target,
+      q: sourceText,
+    };
 
+  chrome.runtime.sendMessage({
+    msgId: "googleTranslate",
+    url: url,
+    params: $.param(urlParams),
+  }, function (result) {
+    // If request was successful.
+    if (result.status) {
+      var response = JSON.parse(result.data);
       if (response && response.sentences && response.sentences.length > 0) {
         var ret = [];
         var expandRet = [];
@@ -454,22 +471,10 @@ BabelFrog.engines.googleTranslateFree = function(sourceText){
       else {
         BabelFrog.config.errorCallback('Google Translate: unable to parse response.');
       }
-    },
-    error: function(xhr, status){
-      BabelFrog.config.errorCallback("Google Translate XHR error: <br/>"  + status);
-    },
-    data: {
-      // appear as the official Google Translate chrome extension
-      client:'gtx',
-      hl:'en-US',
-      source:'bubble',
-      tk: (Math.floor((new Date).getTime() / 36E5) ^ 123456) + "|" + (Math.floor((Math.sqrt(5) - 1) / 2 * ((Math.floor((new Date).getTime() / 36E5) ^ 123456) ^ 654321) % 1 * 1048576)),
-      dt: 'bd',
-      dt: 't',
-      dj: 1,
-      sl: BabelFrog.config.source,
-      tl: BabelFrog.config.target,
-      q: sourceText
+    }
+    else {
+      BabelFrog.config.errorCallback("Google Translate XHR error: <br/>"  + result.message);
     }
   });
+
 }

--- a/src/inject/babelfrog.js
+++ b/src/inject/babelfrog.js
@@ -430,7 +430,7 @@ BabelFrog.engines.googleTranslateFree = function(sourceText){
   chrome.runtime.sendMessage({
     msgId: "googleTranslate",
     url: url,
-    params: $.param(urlParams),
+    params: urlParams,
   }, function (result) {
     // If request was successful.
     if (result.status) {


### PR DESCRIPTION
Vocalization was not working due to new Chrome autoplay policy. Fixed by capturing promise returned by the play function.

Chrome 73 had a new policy for cross-origin request script that didn't allow our Ajax call to take place in the App file. Fixed by moving the call to background.js using messages.